### PR TITLE
优化打包逻辑

### DIFF
--- a/run.py
+++ b/run.py
@@ -1528,10 +1528,16 @@ def insuper(Imgdir, outputimg, ssize, stype, sparse):
                         group_size_b += img_sizeb
                         superpa += f"--partition {image}_a:readonly:{img_sizea}:{settings.super_group}_a --image {image}_a={Imgdir}{os.sep}{image}_a.img --partition {image}_b:readonly:{img_sizeb}:{settings.super_group}_b --image {image}_b={Imgdir}{os.sep}{image}_b.img "
                     else:
-                        img_size = os.path.getsize(Imgdir + os.sep + image + ".img")
-                        group_size_a += img_size
-                        group_size_b += img_size
-                        superpa += f"--partition {image}_a:readonly:{img_size}:{settings.super_group}_a --image {image}_a={Imgdir}{os.sep}{image}.img --partition {image}_b:readonly:0:{settings.super_group}_b "
+                        if os.path.isfile(Imgdir + os.sep + image + "_a.img"):
+                            img_size = os.path.getsize(Imgdir + os.sep + image + "_a.img")
+                            group_size_a += img_size
+                            group_size_b += img_size
+                            superpa += f"--partition {image}_a:readonly:{img_size}:{settings.super_group}_a --image {image}_a={Imgdir}{os.sep}{image}_a.img --partition {image}_b:readonly:0:{settings.super_group}_b "
+                        else:
+                            img_size = os.path.getsize(Imgdir + os.sep + image + ".img")
+                            group_size_a += img_size
+                            group_size_b += img_size
+                            superpa += f"--partition {image}_a:readonly:{img_size}:{settings.super_group}_a --image {image}_a={Imgdir}{os.sep}{image}.img --partition {image}_b:readonly:0:{settings.super_group}_b "
                 else:
                     img_size = os.path.getsize(Imgdir + os.sep + image + ".img")
                     superpa += f"--partition {image}:readonly:{img_size}:{settings.super_group} --image {image}={Imgdir}{os.sep}{image}.img "


### PR DESCRIPTION
现在解包后得到带 _a 名称的 img 文件能够直接打包到 super.img 了，并且保持名称不变