### PR TITLE
contextpatch: neglect blank rows

### DIFF
--- a/contextpatch.py
+++ b/contextpatch.py
@@ -22,7 +22,10 @@ fix_permission = {
 def scan_context(file) -> dict:  # 读取context文件返回一个字典
     context = {}
     with open(file, "r", encoding='utf-8') as file_:
-        for i in file_.readlines():
+        for line_number, i in enumerate(file_.readlines(), start=1):
+            if not i.strip():
+                print(f"[Warn] line {line_number} is empty.Skip.")
+                continue
             filepath, *other = i.strip().split()
             filepath = filepath.replace(r'\@', '@')
             context[filepath] = other


### PR DESCRIPTION
error:
Traceback (most recent call last):
File "run.py", line 1924, in
File "run.py", line 557, in main
File "run.py", line 628, in project
File "run.py", line 1264, in packChoo
File "run.py", line 1480, in inpacker
File "contextpatch.py", line 101, in main
File "contextpatch.py", line 26, in scan_context
ValueError: not enough values to unpack (expected at least 1, got 0)
[143640] Failed to execute script 'run' due to unhandled exception!

cause:
File "contextpatch.py", line 26, in scan_context
filepath, *other = i.strip().split(): i may read a blank line.

for example, someone may manually add selinux rules and leave a blank line, then error occurs.
/vendor/tee u:object_r:tee_file:s0
/vendor/tee/driver u:object_r:tee_file:s0
/vendor/vm-system u:object_r:same_process_hal_file:s0

/vendor/lib/(.)?.so u:object_r:same_process_hal_file:s0
/vendor/lib/egl/(.)?.so u:object_r:same_process_hal_file:s0